### PR TITLE
Prepare package for pypi

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2018 The Python Packaging Authority
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pysplines/alexpression.py
+++ b/pysplines/alexpression.py
@@ -20,7 +20,7 @@ class ALexpression:
     def __init__(self, sympy_expression):
         self.aform = sympy_expression
         self.__initial_aform = sympy_expression
-        self.t = sympy_expression.free_symbols
+        self.t = tuple(sympy_expression.free_symbols)
         if len(self.t) > 1:
             warnings.warn(
                 "Be careful with the lambdified expression {}, "

--- a/pysplines/bsplines.py
+++ b/pysplines/bsplines.py
@@ -10,7 +10,6 @@ import sympy
 from sympy.functions.special.bsplines import bspline_basis as sympy_bspline_basis
 import math
 from scipy.integrate import simps
-import matplotlib.pyplot as plt
 import warnings
 
 from pysplines.alexpression import ALexpression
@@ -295,6 +294,7 @@ class Bspline(CoreBspline):
 
     def plot(self, linetype="-", window=None, **kwargs):
         if window is None:
+            import matplotlib.pyplot as plt
             window = plt
         window.plot(
             np.array(self.rvals)[:, 0],
@@ -309,6 +309,7 @@ class Bspline(CoreBspline):
 
     def plot_cv(self, window=None):
         if window is None:
+            import matplotlib.pyplot as plt
             window = plt
         window.plot(
             self.cv[:, 0], self.cv[:, 1], "o", markersize=4, c="black", mfc="none"

--- a/setup.py
+++ b/setup.py
@@ -2,25 +2,26 @@
 Setup configuration for installation via pip
 """
 
-import sys
 from setuptools import setup, find_packages
 
 
 # The find_packages function does a lot of the heavy lifting for us w.r.t.
 # discovering any Python packages we ship.
 setup(
-    name='pysplines',
-    version='0.1dev',
+    name="pysplines",
+    version="0.1.0.dev2",
+    author="Petr Kungurtsev",
     packages=find_packages(),
-
     # PyPI packages required for the *installation* and usual running of the
     # tools.
-    install_requires=[
-        'numpy',
-        'sympy',
-        'scipy'
-    ],
-
+    install_requires=["numpy", "sympy", "scipy"],
     # Metadata for PyPI (https://pypi.python.org).
-    description='Tool to create discrete b-splines for shape optimization',
+    description="Tool to create discrete b-splines with surface properties",
+    url="https://github.com/Corwinpro/PySplines",
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+    python_requires=">=3.6",
 )


### PR DESCRIPTION
- Update `setup.py` and the LICENSE file
- Fix minor issue with `sympy=1.7` deprecation warning
- _Try_ to avoid `matplotlib` dependency by moving the export to the `.plot` methods

The package is now uploaded to https://pypi.org/project/pysplines/