### PR TITLE
Optimize `BSpline` initialization

### DIFF
--- a/pysplines/alexpression.py
+++ b/pysplines/alexpression.py
@@ -137,6 +137,6 @@ class ALexpression:
             level == 1: full simplification through sympy.simplify
         """
         if level == 0:
-            self.aform = sympy.cancel(self.__initial_aform)
+            self.aform = sympy.factor(self.__initial_aform)
         elif level == 1:
             self.aform = sympy.simplify(self.__initial_aform)


### PR DESCRIPTION
Minor improvements for `BSpline` initialization step:
- in `ALexpression.simplify`: use `factor` instead of `cancel` (which appears to be faster for polynomials)
- refactor `BSpline.generate_surface_properties` to generate those properties lazily