### PR TITLE
Fix first order bspline corner points

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .vscode/
 __pycache__/
 pysplines.egg-info/
+*.pyc
+.idea/

--- a/pysplines/bsplines.py
+++ b/pysplines/bsplines.py
@@ -39,7 +39,7 @@ class CoreBspline:
 
         self.max_param = self.cv.shape[0] - (self.degree * (1 - self.periodic))
         self.kv = self.construct_knot_vector()
-        self.dom = np.linspace(0, self.max_param, self.n)
+        self.dom = np.linspace(0, self.max_param, self.n + 1)
 
         self.point_to_t_dict = {}
         self.tolerance = 1.0e-6
@@ -141,6 +141,11 @@ class Bspline(CoreBspline):
         self.__normal = None
         self.__curvature = None
         self.__displacement = None
+
+        if self.degree == 1:
+            self.n = len(self.cv) - 1
+            self.dom = np.linspace(0, self.max_param, self.n + 1)
+            return
 
         if kwargs.get("normalize_points", True):
             self.normalize_points(self.n)

--- a/pysplines/bsplines.py
+++ b/pysplines/bsplines.py
@@ -379,35 +379,6 @@ class Bspline(CoreBspline):
                     self.rvals[i][j], -int(math.log10(self.tolerance))
                 )
 
-    def _insert_surface_points(self):
-        """
-        For splines of degree 1, the spline passes through the control points.
-        Naively iterate over all points and find proper places to add the control
-        points.
-        Mutates ``self.rvals``.
-        """
-
-        def collinear(p0, p1, p2, tolerance=1.0e-12):
-            x1, y1 = p1[0] - p0[0], p1[1] - p0[1]
-            x2, y2 = p2[0] - p0[0], p2[1] - p0[1]
-            offset = abs(x1 * y2 - x2 * y1)
-            return offset < tolerance
-
-        vertices = [[_cv for _cv in cv] for cv in self.cv]
-        current_vertex_index = 1
-
-        rvals = [vertices[0]]
-        for rval_index, rval in enumerate(self.rvals[1:-1], start=1):
-            if not collinear(
-                vertices[current_vertex_index - 1], vertices[current_vertex_index], rval
-            ):
-                rvals.append(vertices[current_vertex_index])
-                current_vertex_index += 1
-            rvals.append(rval)
-
-        rvals.append(vertices[-1])
-        self.rvals = rvals
-
     def normalize_points(self, n):
         """
         Reconstructs the distribution of the internal parameter t in self.dom which corresponds to

--- a/pysplines/bsplines.py
+++ b/pysplines/bsplines.py
@@ -145,12 +145,11 @@ class Bspline(CoreBspline):
         if self.degree == 1:
             self.n = len(self.cv) - 1
             self.dom = np.linspace(0, self.max_param, self.n + 1)
-            return
-
-        if kwargs.get("normalize_points", True):
+        elif kwargs.get("normalize_points", True):
             self.normalize_points(self.n)
-        else:
-            self.bspline_get_surface()
+
+        self.bspline_get_surface()
+        self.n = len(self.dom)
 
         self.is_bspline_refined = kwargs.get("refine", False)
         if self.is_bspline_refined:
@@ -379,8 +378,6 @@ class Bspline(CoreBspline):
                 self.rvals[i][j] = round(
                     self.rvals[i][j], -int(math.log10(self.tolerance))
                 )
-        if self.degree == 1:
-            self._insert_surface_points()
 
     def _insert_surface_points(self):
         """
@@ -454,8 +451,6 @@ class Bspline(CoreBspline):
         proper_t_dist.append(self.dom[-1])
 
         self.dom = proper_t_dist
-        self.bspline_get_surface()
-        self.n = len(self.dom)
 
     def dots_angles(self, direction="forward"):
         """

--- a/pysplines/tests/test_bspline.py
+++ b/pysplines/tests/test_bspline.py
@@ -9,8 +9,8 @@ _TOLERANCE = 5.0e-7
 
 class TestBspline(unittest.TestCase):
     def setUp(self):
-        cv = [[0.0, 0.0], [0.0, 1.0], [1.0, 1.0], [2.0, 1.0], [2.0, 2.0]]
-        self.bspline = Bspline(cv, n=120)
+        self.cv = [[0.0, 0.0], [0.0, 1.0], [1.0, 1.0], [2.0, 1.0], [2.0, 2.0]]
+        self.bspline = Bspline(self.cv, n=120)
 
     def test_edge_points(self):
         rvals = np.array(self.bspline.rvals)
@@ -52,3 +52,15 @@ class TestBspline(unittest.TestCase):
             )
             < _TOLERANCE
         )
+
+    def test_bspline_first_order(self):
+        # When
+        spline = Bspline(cv=self.cv, degree=1)
+
+        # Then
+        self.assertEqual(len(spline.rvals), 5)
+        self.assertListEqual(spline.rvals, self.cv)
+
+
+if __name__=="__main__":
+    unittest.main()

--- a/pysplines/tests/test_core_bspline.py
+++ b/pysplines/tests/test_core_bspline.py
@@ -13,7 +13,7 @@ class TestCoreBspline(unittest.TestCase):
 
     def test_bspline_domain(self):
         self.assertEqual(self.core_bspline.n, 120)
-        self.assertEqual(len(self.core_bspline.dom), 120)
+        self.assertEqual(len(self.core_bspline.dom), 121)
 
     def test_bspline_basis(self):
         x = sp.var("x")
@@ -54,7 +54,7 @@ class TestCoreBspline(unittest.TestCase):
     def test_bspline_evaluate_expression(self):
         expression = self.core_bspline.bspline
 
-        self.assertEqual(len(self.core_bspline.evaluate_expression(expression)), 120)
+        self.assertEqual(len(self.core_bspline.evaluate_expression(expression)), 121)
         self.assertListEqual(
             self.core_bspline.evaluate_expression(expression, domain=1), [1.0, 1.0]
         )


### PR DESCRIPTION
Fix an off by one error that affected the 1st order bspline generation.

Change the number of boundary points in the 1st order case: only include the control points themselves, and nothing in between.

Also, minor refactoring.